### PR TITLE
Deploy Elsewhere publicly and ready Twilio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+data/
+server/.env
+.DS_Store
+*.log

--- a/css/styles.css
+++ b/css/styles.css
@@ -297,6 +297,24 @@ textarea {
   max-width: 46ch;
 }
 
+.trip-webhook {
+  margin: 0.55rem 0 0;
+  color: var(--sea-deep);
+  font-size: 0.92rem;
+  font-weight: 600;
+  word-break: break-all;
+  max-width: 52ch;
+}
+
+.trip-setup {
+  margin: 0 0 1.5rem;
+  padding-left: 1.2rem;
+  color: var(--ink-soft);
+  max-width: 46rem;
+  display: grid;
+  gap: 0.45rem;
+}
+
 .trip-tips {
   margin: 0 0 1.75rem;
   padding: 0;

--- a/css/styles.css
+++ b/css/styles.css
@@ -255,16 +255,151 @@ textarea {
   color: var(--ink-soft);
 }
 
+.trip,
 .journal {
   position: relative;
 }
 
+.trip::before,
 .journal::before {
   content: "";
   position: absolute;
   inset: 1.5rem 0 auto;
   height: 1px;
   background: linear-gradient(90deg, transparent, var(--line), transparent);
+}
+
+.trip-status {
+  display: grid;
+  gap: 0.35rem;
+  margin-bottom: 1.25rem;
+}
+
+.trip-kicker {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.trip-phone {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3.5vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  color: var(--sea-deep);
+}
+
+.trip-help {
+  margin: 0.15rem 0 0;
+  color: var(--ink-soft);
+  max-width: 46ch;
+}
+
+.trip-tips {
+  margin: 0 0 1.75rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+  color: var(--ink-soft);
+  font-size: 0.95rem;
+}
+
+.trip-tips li {
+  padding-left: 1rem;
+  position: relative;
+}
+
+.trip-tips li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.7em;
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--lagoon);
+}
+
+.moment-list {
+  display: grid;
+  gap: 1.1rem;
+}
+
+.moment {
+  display: grid;
+  gap: 0.55rem;
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--line);
+  animation: fade-up 700ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.moment-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+}
+
+.moment-kind {
+  font-family: var(--font-display);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.moment-time {
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.moment-text {
+  margin: 0;
+  color: var(--ink-soft);
+  white-space: pre-wrap;
+}
+
+.moment-photo {
+  width: min(100%, 420px);
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 16px;
+}
+
+.moment audio {
+  width: min(100%, 420px);
+}
+
+.moment-actions {
+  display: flex;
+  gap: 0.6rem;
+}
+
+.moment-actions .btn {
+  min-height: 2.2rem;
+  padding: 0.4rem 0.85rem;
+  font-size: 0.9rem;
+}
+
+.demo-panel {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+}
+
+.demo-panel summary {
+  cursor: pointer;
+  font-weight: 700;
+  color: var(--sea-deep);
+}
+
+.demo-form {
+  display: grid;
+  gap: 0.9rem;
+  margin-top: 1rem;
+  max-width: 32rem;
 }
 
 .journal-list {
@@ -607,7 +742,7 @@ textarea:focus {
     gap: 0.75rem;
   }
 
-  .nav a:not(.nav-cta) {
+  .nav a:not(.nav-cta):not([href="#trip"]) {
     display: none;
   }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <header class="site-header">
     <a class="logo" href="#top" aria-label="Elsewhere home">Elsewhere</a>
     <nav class="nav" aria-label="Primary">
+      <a href="#trip">Trip</a>
       <a href="#journal">Journal</a>
       <a href="#album">Album</a>
       <a href="#write" class="nav-cta">Write</a>
@@ -30,12 +31,45 @@
       <div class="hero-copy">
         <p class="brand">Elsewhere</p>
         <h1>Keep the road in your pocket.</h1>
-        <p class="lede">A soft little home for the photos you take and the stories that trail behind them.</p>
+        <p class="lede">A soft little home for the photos you take, the notes you write, and the moments you text from the road.</p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="#write">Start a note</a>
-          <a class="btn btn-ghost" href="#album">Open the album</a>
+          <a class="btn btn-primary" href="#trip">Text it in</a>
+          <a class="btn btn-ghost" href="#write">Start a note</a>
         </div>
       </div>
+    </section>
+
+    <section id="trip" class="section trip">
+      <div class="section-head">
+        <h2>Trip inbox</h2>
+        <p>Text a photo or voice memo to your Elsewhere number and it lands here.</p>
+      </div>
+
+      <div class="trip-status" id="trip-status" aria-live="polite">
+        <p class="trip-kicker" id="trip-name">Current trip</p>
+        <p class="trip-phone" id="trip-phone">Connecting…</p>
+        <p class="trip-help" id="trip-help">Start the Elsewhere server to enable texting-in.</p>
+      </div>
+
+      <ul class="trip-tips" id="trip-tips"></ul>
+
+      <div id="moment-list" class="moment-list" aria-live="polite"></div>
+      <p id="moment-empty" class="empty-state hidden">Nothing texted in yet — send a photo, a voice memo, or a quick note.</p>
+
+      <details class="demo-panel" id="demo-panel" hidden>
+        <summary>Try a demo text (no Twilio needed)</summary>
+        <form id="demo-form" class="demo-form" method="post" action="#">
+          <label>
+            Message
+            <input type="text" id="demo-body" name="body" placeholder="TRIP Algarve" maxlength="300">
+          </label>
+          <label class="attach-label">
+            Attach a photo or voice memo
+            <input id="demo-media" type="file" accept="image/*,audio/*">
+          </label>
+          <button type="submit" class="btn btn-primary">Send demo text</button>
+        </form>
+      </details>
     </section>
 
     <section id="journal" class="section journal">
@@ -127,6 +161,7 @@
   </dialog>
 
   <script src="js/db.js"></script>
+  <script src="js/trip.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,10 @@
         <p class="trip-kicker" id="trip-name">Current trip</p>
         <p class="trip-phone" id="trip-phone">Connecting…</p>
         <p class="trip-help" id="trip-help">Start the Elsewhere server to enable texting-in.</p>
+        <p class="trip-webhook" id="trip-webhook" hidden></p>
       </div>
+
+      <ol class="trip-setup" id="trip-setup" hidden></ol>
 
       <ul class="trip-tips" id="trip-tips"></ul>
 

--- a/js/app.js
+++ b/js/app.js
@@ -85,9 +85,24 @@ function renderPhotoPreview(container, files) {
   });
 }
 
+function textedPhotos() {
+  const moments = window.ElsewhereTrip?.getMoments?.() || [];
+  return moments
+    .filter((moment) => moment.kind === "photo" && moment.mediaUrl)
+    .map((moment) => ({
+      id: `trip-${moment.id}`,
+      dataUrl: moment.mediaUrl,
+      caption: moment.text || "Texted in",
+      place: "",
+      createdAt: moment.createdAt,
+      source: "sms",
+      momentId: moment.id,
+    }));
+}
+
 function renderAlbum() {
   els.albumGrid.innerHTML = "";
-  const photos = [...state.photos].sort(
+  const photos = [...state.photos, ...textedPhotos()].sort(
     (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
   );
 
@@ -113,8 +128,13 @@ function renderAlbum() {
     remove.setAttribute("aria-label", "Remove photo");
     remove.textContent = "×";
     remove.addEventListener("click", async () => {
-      await deleteItem("photos", photo.id);
-      state.photos = state.photos.filter((item) => item.id !== photo.id);
+      if (photo.source === "sms" && photo.momentId) {
+        await fetch(`/api/moments/${photo.momentId}`, { method: "DELETE" });
+        await window.ElsewhereTrip?.refresh?.();
+      } else {
+        await deleteItem("photos", photo.id);
+        state.photos = state.photos.filter((item) => item.id !== photo.id);
+      }
       renderAlbum();
     });
 
@@ -341,6 +361,10 @@ async function init() {
   bindEvents();
   renderAlbum();
   renderJournal();
+
+  window.addEventListener("elsewhere:trip-updated", () => {
+    renderAlbum();
+  });
 }
 
 init().catch((error) => {

--- a/js/trip.js
+++ b/js/trip.js
@@ -3,6 +3,8 @@
     tripName: document.getElementById("trip-name"),
     tripPhone: document.getElementById("trip-phone"),
     tripHelp: document.getElementById("trip-help"),
+    tripWebhook: document.getElementById("trip-webhook"),
+    tripSetup: document.getElementById("trip-setup"),
     tripTips: document.getElementById("trip-tips"),
     momentList: document.getElementById("moment-list"),
     momentEmpty: document.getElementById("moment-empty"),
@@ -69,7 +71,9 @@
       els.tripName.textContent = "Trip inbox offline";
       els.tripPhone.textContent = "Start the server";
       els.tripHelp.textContent =
-        "Run npm start inside /server, then refresh. Demo texting works even before Twilio is connected.";
+        "Run npm start, then refresh. Demo texting works even before Twilio is connected.";
+      els.tripWebhook.hidden = true;
+      els.tripSetup.hidden = true;
       els.tripTips.innerHTML = "";
       els.demoPanel.hidden = true;
       return;
@@ -83,13 +87,31 @@
       : "Add your Twilio number";
     els.tripHelp.textContent = status.twilioConfigured
       ? "Text a photo or voice memo to this number (SMS/MMS — green bubble on iPhone)."
-      : "Twilio isn’t connected yet. Use the demo form below, or add keys in server/.env.";
+      : "Twilio isn’t connected yet. Finish the setup steps below, or use the demo form.";
+
+    if (status.webhookUrl) {
+      els.tripWebhook.hidden = false;
+      els.tripWebhook.textContent = `Webhook: ${status.webhookUrl}`;
+    } else {
+      els.tripWebhook.hidden = true;
+    }
+
+    const setup = status.setup || [];
+    if (setup.length) {
+      els.tripSetup.hidden = false;
+      els.tripSetup.innerHTML = setup
+        .map((step) => `<li>${escapeHtml(step)}</li>`)
+        .join("");
+    } else {
+      els.tripSetup.hidden = true;
+      els.tripSetup.innerHTML = "";
+    }
 
     els.tripTips.innerHTML = (status.tips || [])
       .map((tip) => `<li>${escapeHtml(tip)}</li>`)
       .join("");
 
-    els.demoPanel.hidden = false;
+    els.demoPanel.hidden = !status.demoEnabled;
   }
 
   function renderMoments() {

--- a/js/trip.js
+++ b/js/trip.js
@@ -1,0 +1,234 @@
+(() => {
+  const els = {
+    tripName: document.getElementById("trip-name"),
+    tripPhone: document.getElementById("trip-phone"),
+    tripHelp: document.getElementById("trip-help"),
+    tripTips: document.getElementById("trip-tips"),
+    momentList: document.getElementById("moment-list"),
+    momentEmpty: document.getElementById("moment-empty"),
+    demoPanel: document.getElementById("demo-panel"),
+    demoForm: document.getElementById("demo-form"),
+    demoBody: document.getElementById("demo-body"),
+    demoMedia: document.getElementById("demo-media"),
+  };
+
+  const state = {
+    online: false,
+    moments: [],
+    trip: null,
+    status: null,
+  };
+
+  function escapeHtml(value) {
+    return String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;");
+  }
+
+  function formatWhen(iso) {
+    if (!iso) return "";
+    return new Date(iso).toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  }
+
+  function kindLabel(kind) {
+    if (kind === "photo") return "Photo";
+    if (kind === "voice") return "Voice memo";
+    if (kind === "video") return "Video";
+    return "Note";
+  }
+
+  function formatPhoneDisplay(value) {
+    if (!value) return "Number not set yet";
+    const digits = String(value).replace(/\D/g, "");
+    if (digits.length === 11 && digits.startsWith("1")) {
+      return `+1 (${digits.slice(1, 4)}) ${digits.slice(4, 7)}-${digits.slice(7)}`;
+    }
+    return value;
+  }
+
+  async function api(path, options) {
+    const response = await fetch(path, options);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `Request failed (${response.status})`);
+    }
+    const type = response.headers.get("content-type") || "";
+    if (type.includes("application/json")) return response.json();
+    return response.text();
+  }
+
+  function renderStatus() {
+    if (!state.online) {
+      els.tripName.textContent = "Trip inbox offline";
+      els.tripPhone.textContent = "Start the server";
+      els.tripHelp.textContent =
+        "Run npm start inside /server, then refresh. Demo texting works even before Twilio is connected.";
+      els.tripTips.innerHTML = "";
+      els.demoPanel.hidden = true;
+      return;
+    }
+
+    const status = state.status || {};
+    const trip = state.trip || status.trip || {};
+    els.tripName.textContent = trip.name || "Current trip";
+    els.tripPhone.textContent = status.twilioConfigured
+      ? formatPhoneDisplay(status.phoneNumber)
+      : "Add your Twilio number";
+    els.tripHelp.textContent = status.twilioConfigured
+      ? "Text a photo or voice memo to this number (SMS/MMS — green bubble on iPhone)."
+      : "Twilio isn’t connected yet. Use the demo form below, or add keys in server/.env.";
+
+    els.tripTips.innerHTML = (status.tips || [])
+      .map((tip) => `<li>${escapeHtml(tip)}</li>`)
+      .join("");
+
+    els.demoPanel.hidden = false;
+  }
+
+  function renderMoments() {
+    els.momentList.innerHTML = "";
+    const moments = state.moments || [];
+    els.momentEmpty.classList.toggle("hidden", moments.length > 0);
+
+    moments.forEach((moment, index) => {
+      const article = document.createElement("article");
+      article.className = "moment";
+      article.style.animationDelay = `${Math.min(index, 8) * 40}ms`;
+
+      const top = document.createElement("div");
+      top.className = "moment-top";
+      top.innerHTML = `
+        <span class="moment-kind">${escapeHtml(kindLabel(moment.kind))}</span>
+        <span class="moment-time">${escapeHtml(formatWhen(moment.createdAt))}</span>
+      `;
+      article.appendChild(top);
+
+      if (moment.text) {
+        const text = document.createElement("p");
+        text.className = "moment-text";
+        text.textContent = moment.text;
+        article.appendChild(text);
+      }
+
+      if (moment.kind === "photo" && moment.mediaUrl) {
+        const img = document.createElement("img");
+        img.className = "moment-photo";
+        img.src = moment.mediaUrl;
+        img.alt = moment.text || "Texted-in travel photo";
+        img.loading = "lazy";
+        article.appendChild(img);
+      }
+
+      if (moment.kind === "voice" && moment.mediaUrl) {
+        const audio = document.createElement("audio");
+        audio.controls = true;
+        audio.preload = "metadata";
+        audio.src = moment.mediaUrl;
+        article.appendChild(audio);
+      }
+
+      if (moment.kind === "video" && moment.mediaUrl) {
+        const video = document.createElement("video");
+        video.controls = true;
+        video.preload = "metadata";
+        video.src = moment.mediaUrl;
+        video.className = "moment-photo";
+        article.appendChild(video);
+      }
+
+      const actions = document.createElement("div");
+      actions.className = "moment-actions";
+      const remove = document.createElement("button");
+      remove.type = "button";
+      remove.className = "btn danger";
+      remove.textContent = "Remove";
+      remove.addEventListener("click", async () => {
+        await api(`/api/moments/${moment.id}`, { method: "DELETE" });
+        state.moments = state.moments.filter((item) => item.id !== moment.id);
+        renderMoments();
+        window.dispatchEvent(new CustomEvent("elsewhere:trip-updated"));
+      });
+      actions.appendChild(remove);
+      article.appendChild(actions);
+
+      els.momentList.appendChild(article);
+    });
+  }
+
+  async function refresh() {
+    try {
+      const [status, tripState] = await Promise.all([
+        api("/api/status"),
+        api("/api/trip"),
+      ]);
+      state.online = true;
+      state.status = status;
+      state.trip = tripState.trip;
+      state.moments = tripState.moments || [];
+      renderStatus();
+      renderMoments();
+      window.dispatchEvent(
+        new CustomEvent("elsewhere:trip-updated", { detail: { moments: state.moments } })
+      );
+    } catch (_error) {
+      state.online = false;
+      state.moments = [];
+      renderStatus();
+      renderMoments();
+    }
+  }
+
+  function fileToDataUrl(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+  }
+
+  function bindDemo() {
+    els.demoForm.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const body = els.demoBody.value.trim();
+      const file = els.demoMedia.files?.[0];
+      const media = [];
+
+      if (file) {
+        media.push({
+          dataUrl: await fileToDataUrl(file),
+          contentType: file.type,
+          filename: file.name,
+        });
+      }
+
+      if (!body && !media.length) return;
+
+      await api("/api/demo/inbound", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body, media }),
+      });
+
+      els.demoForm.reset();
+      await refresh();
+    });
+  }
+
+  window.ElsewhereTrip = {
+    refresh,
+    getMoments: () => state.moments,
+    isOnline: () => state.online,
+  };
+
+  bindDemo();
+  refresh();
+  setInterval(refresh, 8000);
+})();

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "elsewhere",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
     "start": "npm --prefix server start",
     "dev": "npm --prefix server run dev",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "elsewhere",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "npm --prefix server start",
+    "dev": "npm --prefix server run dev",
+    "setup": "npm --prefix server install"
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,28 @@
+services:
+  - type: web
+    name: elsewhere
+    runtime: node
+    plan: free
+    region: oregon
+    buildCommand: npm run setup
+    startCommand: npm start
+    healthCheckPath: /health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: ENABLE_DEMO
+        value: "false"
+      - key: ALLOW_UNSIGNED_WEBHOOKS
+        value: "false"
+      # Render sets RENDER_EXTERNAL_URL automatically; override only if needed
+      - key: PUBLIC_BASE_URL
+        sync: false
+      - key: TWILIO_ACCOUNT_SID
+        sync: false
+      - key: TWILIO_AUTH_TOKEN
+        sync: false
+      - key: TWILIO_PHONE_NUMBER
+        sync: false
+      # Your personal phone in E.164, e.g. +15551234567
+      - key: ALLOWED_FROM
+        sync: false

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,14 +1,19 @@
 PORT=8787
-# Public base URL Twilio can reach, e.g. https://abc123.ngrok.app
+HOST=0.0.0.0
+NODE_ENV=development
+
+# Public HTTPS URL Twilio can reach.
+# On Render, leave blank to use RENDER_EXTERNAL_URL automatically.
 PUBLIC_BASE_URL=http://localhost:8787
 
-# From your Twilio console
+# From https://console.twilio.com
 TWILIO_ACCOUNT_SID=
 TWILIO_AUTH_TOKEN=
-TWILIO_PHONE_NUMBER=+15551234567
+TWILIO_PHONE_NUMBER=
 
-# Comma-separated numbers allowed to text in (E.164). Empty = allow any in demo/dev.
+# Comma-separated numbers allowed to text in (E.164). Recommended in production.
 ALLOWED_FROM=
 
-# Set to false in production so only Twilio-signed webhooks are accepted
+# Production defaults: signed webhooks on, demo off
 ALLOW_UNSIGNED_WEBHOOKS=true
+ENABLE_DEMO=true

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,14 @@
+PORT=8787
+# Public base URL Twilio can reach, e.g. https://abc123.ngrok.app
+PUBLIC_BASE_URL=http://localhost:8787
+
+# From your Twilio console
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=+15551234567
+
+# Comma-separated numbers allowed to text in (E.164). Empty = allow any in demo/dev.
+ALLOWED_FROM=
+
+# Set to false in production so only Twilio-signed webhooks are accepted
+ALLOW_UNSIGNED_WEBHOOKS=true

--- a/server/inbound.js
+++ b/server/inbound.js
@@ -1,0 +1,119 @@
+import { addMoment, renameTrip, startNewTrip, saveMediaBuffer } from "./store.js";
+
+const TRIP_COMMAND = /^(?:trip|start(?:\s+trip)?)\s*[:\-]?\s*(.+)$/i;
+const PLACE_COMMAND = /^(?:place|in)\s*[:\-]?\s*(.+)$/i;
+
+export function classifyMedia(contentType = "") {
+  const type = contentType.toLowerCase();
+  if (type.startsWith("image/")) return "photo";
+  if (type.startsWith("audio/")) return "voice";
+  if (type.startsWith("video/")) return "video";
+  return "file";
+}
+
+export async function downloadMedia(url, { accountSid, authToken } = {}) {
+  const headers = {};
+  if (accountSid && authToken) {
+    const token = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+    headers.Authorization = `Basic ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to download media (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type") || "application/octet-stream";
+  const buffer = Buffer.from(await response.arrayBuffer());
+  return { buffer, contentType };
+}
+
+export async function processInboundMessage({
+  from = "",
+  to = "",
+  body = "",
+  media = [],
+  messageSid = "",
+  accountSid = "",
+  authToken = "",
+}) {
+  const text = String(body || "").trim();
+  const created = [];
+
+  const tripMatch = text.match(TRIP_COMMAND);
+  if (tripMatch) {
+    const name = tripMatch[1].trim();
+    const trip = await startNewTrip({ name, place: name });
+    const moment = await addMoment({
+      kind: "note",
+      text: `Started trip: ${trip.name}`,
+      from,
+      to,
+      messageSid,
+      source: "sms",
+    });
+    created.push(moment);
+    return { tripCommand: "start", trip, moments: created };
+  }
+
+  const placeMatch = text.match(PLACE_COMMAND);
+  if (placeMatch && media.length === 0) {
+    const place = placeMatch[1].trim();
+    const trip = await renameTrip({ name: place, place });
+    const moment = await addMoment({
+      kind: "note",
+      text: `Now in ${place}`,
+      from,
+      to,
+      messageSid,
+      source: "sms",
+    });
+    created.push(moment);
+    return { tripCommand: "place", trip, moments: created };
+  }
+
+  for (const item of media) {
+    let buffer = item.buffer;
+    let contentType = item.contentType || "application/octet-stream";
+
+    if (!buffer && item.url) {
+      const downloaded = await downloadMedia(item.url, { accountSid, authToken });
+      buffer = downloaded.buffer;
+      contentType = item.contentType || downloaded.contentType;
+    }
+
+    if (!buffer) continue;
+
+    const saved = await saveMediaBuffer(buffer, {
+      contentType,
+      originalName: item.filename || "",
+    });
+    const kind = classifyMedia(contentType);
+    const moment = await addMoment({
+      kind,
+      text: text || "",
+      from,
+      to,
+      messageSid,
+      source: "sms",
+      mediaUrl: saved.url,
+      contentType: saved.contentType,
+      filename: saved.filename,
+    });
+    created.push(moment);
+  }
+
+  if (!media.length && text) {
+    const moment = await addMoment({
+      kind: "note",
+      text,
+      from,
+      to,
+      messageSid,
+      source: "sms",
+    });
+    created.push(moment);
+  }
+
+  return { tripCommand: null, moments: created };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -8,8 +8,14 @@ import { processInboundMessage } from "./inbound.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, "..");
+const IS_PROD = process.env.NODE_ENV === "production";
 const PORT = Number(process.env.PORT || 8787);
-const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`).replace(/\/$/, "");
+const HOST = process.env.HOST || "0.0.0.0";
+const PUBLIC_BASE_URL = (
+  process.env.PUBLIC_BASE_URL ||
+  process.env.RENDER_EXTERNAL_URL ||
+  `http://localhost:${PORT}`
+).replace(/\/$/, "");
 const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID || "";
 const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN || "";
 const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER || "";
@@ -17,7 +23,12 @@ const ALLOWED_FROM = String(process.env.ALLOWED_FROM || "")
   .split(",")
   .map((value) => value.trim())
   .filter(Boolean);
-const ALLOW_UNSIGNED_WEBHOOKS = String(process.env.ALLOW_UNSIGNED_WEBHOOKS || "true") === "true";
+const ALLOW_UNSIGNED_WEBHOOKS =
+  String(
+    process.env.ALLOW_UNSIGNED_WEBHOOKS ?? (IS_PROD ? "false" : "true")
+  ) === "true";
+const ENABLE_DEMO =
+  String(process.env.ENABLE_DEMO ?? (IS_PROD ? "false" : "true")) === "true";
 
 const app = express();
 
@@ -69,15 +80,21 @@ function twimlMessage(text) {
   return `<?xml version="1.0" encoding="UTF-8"?><Response><Message>${safe}</Message></Response>`;
 }
 
+app.get("/health", (_req, res) => {
+  res.status(200).json({ ok: true });
+});
+
 app.get("/api/status", async (_req, res) => {
   const state = await getTripState();
   res.json({
     ok: true,
+    production: IS_PROD,
     twilioConfigured: twilioConfigured(),
-    phoneNumber: TWILIO_PHONE_NUMBER || null,
+    phoneNumber: twilioConfigured() ? TWILIO_PHONE_NUMBER : null,
     publicBaseUrl: PUBLIC_BASE_URL,
     webhookUrl: `${PUBLIC_BASE_URL}/webhooks/twilio`,
-    allowedFrom: ALLOWED_FROM,
+    allowedFromConfigured: ALLOWED_FROM.length > 0,
+    demoEnabled: ENABLE_DEMO,
     trip: state.trip,
     momentCount: state.moments.length,
     tips: [
@@ -86,6 +103,14 @@ app.get("/api/status", async (_req, res) => {
       'Send "PLACE Porto" to update where you are.',
       "iPhone: use SMS/MMS (green bubble), not iMessage.",
     ],
+    setup: twilioConfigured()
+      ? []
+      : [
+          "Create a Twilio account and buy an SMS-capable number.",
+          "Set TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_PHONE_NUMBER.",
+          "Point the number’s Messaging webhook to /webhooks/twilio (HTTP POST).",
+          "Optionally set ALLOWED_FROM to your personal phone in E.164 (+1…).",
+        ],
   });
 });
 
@@ -135,8 +160,11 @@ app.post("/webhooks/twilio", async (req, res) => {
   }
 });
 
-// Local/demo helper so you can try the flow without Twilio credentials.
 app.post("/api/demo/inbound", async (req, res) => {
+  if (!ENABLE_DEMO) {
+    return res.status(404).json({ error: "Demo inbound is disabled" });
+  }
+
   try {
     const {
       from = "+15550001111",
@@ -184,10 +212,11 @@ app.post("/api/demo/inbound", async (req, res) => {
   }
 });
 
-app.listen(PORT, () => {
-  console.log(`Elsewhere listening on http://localhost:${PORT}`);
+app.listen(PORT, HOST, () => {
+  console.log(`Elsewhere listening on http://${HOST}:${PORT}`);
+  console.log(`Public URL: ${PUBLIC_BASE_URL}`);
   console.log(`Webhook URL: ${PUBLIC_BASE_URL}/webhooks/twilio`);
   if (!twilioConfigured()) {
-    console.log("Twilio not configured yet — use /api/demo/inbound or fill server/.env");
+    console.log("Twilio not configured yet — add TWILIO_* env vars to go live");
   }
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,193 @@
+import "dotenv/config";
+import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import twilio from "twilio";
+import { getTripState, deleteMoment, mediaDir } from "./store.js";
+import { processInboundMessage } from "./inbound.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.join(__dirname, "..");
+const PORT = Number(process.env.PORT || 8787);
+const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`).replace(/\/$/, "");
+const TWILIO_ACCOUNT_SID = process.env.TWILIO_ACCOUNT_SID || "";
+const TWILIO_AUTH_TOKEN = process.env.TWILIO_AUTH_TOKEN || "";
+const TWILIO_PHONE_NUMBER = process.env.TWILIO_PHONE_NUMBER || "";
+const ALLOWED_FROM = String(process.env.ALLOWED_FROM || "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+const ALLOW_UNSIGNED_WEBHOOKS = String(process.env.ALLOW_UNSIGNED_WEBHOOKS || "true") === "true";
+
+const app = express();
+
+app.use(express.urlencoded({ extended: false }));
+app.use(express.json({ limit: "12mb" }));
+app.use("/media", express.static(mediaDir()));
+app.use(express.static(ROOT));
+
+function formatPhone(value) {
+  return String(value || "").trim();
+}
+
+function isAllowedSender(from) {
+  if (!ALLOWED_FROM.length) return true;
+  return ALLOWED_FROM.includes(formatPhone(from));
+}
+
+function twilioConfigured() {
+  return Boolean(TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN && TWILIO_PHONE_NUMBER);
+}
+
+function validateTwilioRequest(req) {
+  if (!twilioConfigured()) return ALLOW_UNSIGNED_WEBHOOKS;
+  if (ALLOW_UNSIGNED_WEBHOOKS && !req.headers["x-twilio-signature"]) return true;
+
+  const signature = req.headers["x-twilio-signature"];
+  if (!signature) return false;
+
+  const url = `${PUBLIC_BASE_URL}${req.originalUrl}`;
+  return twilio.validateRequest(TWILIO_AUTH_TOKEN, signature, url, req.body || {});
+}
+
+function extractTwilioMedia(body = {}) {
+  const count = Number(body.NumMedia || 0);
+  const media = [];
+  for (let i = 0; i < count; i += 1) {
+    const url = body[`MediaUrl${i}`];
+    const contentType = body[`MediaContentType${i}`] || "";
+    if (url) media.push({ url, contentType });
+  }
+  return media;
+}
+
+function twimlMessage(text) {
+  const safe = String(text || "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+  return `<?xml version="1.0" encoding="UTF-8"?><Response><Message>${safe}</Message></Response>`;
+}
+
+app.get("/api/status", async (_req, res) => {
+  const state = await getTripState();
+  res.json({
+    ok: true,
+    twilioConfigured: twilioConfigured(),
+    phoneNumber: TWILIO_PHONE_NUMBER || null,
+    publicBaseUrl: PUBLIC_BASE_URL,
+    webhookUrl: `${PUBLIC_BASE_URL}/webhooks/twilio`,
+    allowedFrom: ALLOWED_FROM,
+    trip: state.trip,
+    momentCount: state.moments.length,
+    tips: [
+      "Text photos or a voice memo to your Elsewhere number.",
+      'Send "TRIP Lisbon" to start/rename the current trip.',
+      'Send "PLACE Porto" to update where you are.',
+      "iPhone: use SMS/MMS (green bubble), not iMessage.",
+    ],
+  });
+});
+
+app.get("/api/trip", async (_req, res) => {
+  res.json(await getTripState());
+});
+
+app.delete("/api/moments/:id", async (req, res) => {
+  const removed = await deleteMoment(req.params.id);
+  if (!removed) return res.status(404).json({ error: "Moment not found" });
+  res.json({ ok: true });
+});
+
+app.post("/webhooks/twilio", async (req, res) => {
+  if (!validateTwilioRequest(req)) {
+    return res.status(403).type("text/plain").send("Invalid Twilio signature");
+  }
+
+  const from = formatPhone(req.body.From);
+  if (!isAllowedSender(from)) {
+    res.type("text/xml").send(twimlMessage("This number isn’t allowed to add to Elsewhere yet."));
+    return;
+  }
+
+  try {
+    const result = await processInboundMessage({
+      from,
+      to: formatPhone(req.body.To),
+      body: req.body.Body || "",
+      media: extractTwilioMedia(req.body),
+      messageSid: req.body.MessageSid || "",
+      accountSid: TWILIO_ACCOUNT_SID,
+      authToken: TWILIO_AUTH_TOKEN,
+    });
+
+    const count = result.moments.length;
+    const reply = result.tripCommand
+      ? `Got it — trip is now “${result.trip.name}”.`
+      : count === 1
+        ? "Saved to your trip."
+        : `Saved ${count} moments to your trip.`;
+
+    res.type("text/xml").send(twimlMessage(reply));
+  } catch (error) {
+    console.error("Twilio webhook failed", error);
+    res.type("text/xml").send(twimlMessage("Couldn’t save that just now. Try once more?"));
+  }
+});
+
+// Local/demo helper so you can try the flow without Twilio credentials.
+app.post("/api/demo/inbound", async (req, res) => {
+  try {
+    const {
+      from = "+15550001111",
+      body = "",
+      media = [],
+    } = req.body || {};
+
+    if (!isAllowedSender(from)) {
+      return res.status(403).json({ error: "Sender not allowed" });
+    }
+
+    const normalizedMedia = [];
+    for (const item of media) {
+      if (item.dataUrl) {
+        const match = String(item.dataUrl).match(/^data:([^;]+);base64,(.+)$/);
+        if (!match) continue;
+        normalizedMedia.push({
+          contentType: item.contentType || match[1],
+          buffer: Buffer.from(match[2], "base64"),
+          filename: item.filename || "",
+        });
+      } else if (item.url) {
+        normalizedMedia.push({
+          url: item.url,
+          contentType: item.contentType || "",
+          filename: item.filename || "",
+        });
+      }
+    }
+
+    const result = await processInboundMessage({
+      from,
+      to: TWILIO_PHONE_NUMBER || "+15550000000",
+      body,
+      media: normalizedMedia,
+      messageSid: `demo-${Date.now()}`,
+      accountSid: TWILIO_ACCOUNT_SID,
+      authToken: TWILIO_AUTH_TOKEN,
+    });
+
+    res.json({ ok: true, ...result, trip: (await getTripState()).trip });
+  } catch (error) {
+    console.error("Demo inbound failed", error);
+    res.status(500).json({ error: error.message || "Demo inbound failed" });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Elsewhere listening on http://localhost:${PORT}`);
+  console.log(`Webhook URL: ${PUBLIC_BASE_URL}/webhooks/twilio`);
+  if (!twilioConfigured()) {
+    console.log("Twilio not configured yet — use /api/demo/inbound or fill server/.env");
+  }
+});

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,0 +1,1185 @@
+{
+  "name": "elsewhere-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "elsewhere-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "dotenv": "^16.4.7",
+        "express": "^4.21.2",
+        "twilio": "^5.4.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scmp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/scmp/-/scmp-2.1.0.tgz",
+      "integrity": "sha512-o/mRQGk9Rcer/jEEw/yw4mwo3EU/NvYvp577/Btqrym9Qy5/MdWGBqipbALgd2lrdWTJ5/gqDusxfnQBxOxT2Q==",
+      "deprecated": "Just use Node.js's crypto.timingSafeEqual()",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/twilio": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.13.1.tgz",
+      "integrity": "sha512-sT+PkhptF4Mf7t8eXFFvPQx4w5VHnBIPXbltGPMFRe+R2GxfRdMuFbuNA/cEm0aQR6LFQOn33+fhClg+TjRVqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.13.5",
+        "dayjs": "^1.11.9",
+        "https-proxy-agent": "^5.0.0",
+        "jsonwebtoken": "^9.0.3",
+        "qs": "^6.14.1",
+        "scmp": "^2.1.0",
+        "xmlbuilder": "^13.0.2"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "elsewhere-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "node --watch index.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.7",
+    "express": "^4.21.2",
+    "twilio": "^5.4.5"
+  }
+}

--- a/server/store.js
+++ b/server/store.js
@@ -1,0 +1,146 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DATA_DIR = path.join(__dirname, "..", "data");
+const MEDIA_DIR = path.join(DATA_DIR, "media");
+const DB_PATH = path.join(DATA_DIR, "trip.json");
+
+function uid() {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function ensureDirs() {
+  await fs.mkdir(MEDIA_DIR, { recursive: true });
+}
+
+async function readDb() {
+  await ensureDirs();
+  try {
+    const raw = await fs.readFile(DB_PATH, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+    const fresh = {
+      trip: {
+        id: uid(),
+        name: "Current trip",
+        place: "",
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      moments: [],
+    };
+    await writeDb(fresh);
+    return fresh;
+  }
+}
+
+async function writeDb(db) {
+  await ensureDirs();
+  await fs.writeFile(DB_PATH, JSON.stringify(db, null, 2));
+}
+
+export async function getTripState() {
+  const db = await readDb();
+  return {
+    trip: db.trip,
+    moments: [...db.moments].sort(
+      (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+    ),
+  };
+}
+
+export async function renameTrip({ name, place = "" }) {
+  const db = await readDb();
+  db.trip.name = name || db.trip.name;
+  db.trip.place = place;
+  db.trip.updatedAt = new Date().toISOString();
+  await writeDb(db);
+  return db.trip;
+}
+
+export async function startNewTrip({ name, place = "" }) {
+  const db = await readDb();
+  db.trip = {
+    id: uid(),
+    name: name || "Current trip",
+    place,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+  db.moments = [];
+  await writeDb(db);
+  return db.trip;
+}
+
+export async function addMoment(moment) {
+  const db = await readDb();
+  const record = {
+    id: uid(),
+    tripId: db.trip.id,
+    createdAt: new Date().toISOString(),
+    ...moment,
+  };
+  db.moments.push(record);
+  db.trip.updatedAt = record.createdAt;
+  await writeDb(db);
+  return record;
+}
+
+export async function deleteMoment(id) {
+  const db = await readDb();
+  const before = db.moments.length;
+  db.moments = db.moments.filter((item) => item.id !== id);
+  if (db.moments.length === before) return false;
+  await writeDb(db);
+  return true;
+}
+
+export async function saveMediaBuffer(buffer, { contentType, originalName }) {
+  await ensureDirs();
+  const ext = extensionFor(contentType, originalName);
+  const filename = `${uid()}${ext}`;
+  const fullPath = path.join(MEDIA_DIR, filename);
+  await fs.writeFile(fullPath, buffer);
+  return {
+    filename,
+    url: `/media/${filename}`,
+    contentType,
+  };
+}
+
+function extensionFor(contentType = "", originalName = "") {
+  const fromName = path.extname(originalName || "");
+  if (fromName) return fromName.toLowerCase();
+
+  const map = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/heic": ".heic",
+    "image/heif": ".heif",
+    "audio/mpeg": ".mp3",
+    "audio/mp3": ".mp3",
+    "audio/mp4": ".m4a",
+    "audio/x-m4a": ".m4a",
+    "audio/m4a": ".m4a",
+    "audio/aac": ".aac",
+    "audio/amr": ".amr",
+    "audio/3gpp": ".3gp",
+    "audio/ogg": ".ogg",
+    "audio/wav": ".wav",
+    "audio/x-wav": ".wav",
+    "video/mp4": ".mp4",
+    "video/quicktime": ".mov",
+  };
+
+  return map[contentType.toLowerCase()] || ".bin";
+}
+
+export function mediaDir() {
+  return MEDIA_DIR;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Gets Elsewhere onto a public URL and ready for a real Twilio number.

### What’s in this PR
- Production hardening: bind `0.0.0.0`, `/health`, auto `RENDER_EXTERNAL_URL`, signed webhooks in prod, demo texting off in prod
- `render.yaml` Blueprint for one-click deploy on Render’s free tier
- Trip inbox shows setup steps + webhook URL until Twilio is connected
- Includes the text-in trip inbox work from #7

### Your steps after merge (or from this branch)
1. **Twilio** — create an account, buy an SMS-capable number, copy Account SID + Auth Token + phone number  
2. **Render** — New → Blueprint → connect this repo → deploy `elsewhere`  
3. In Render, set env vars: `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, `ALLOWED_FROM` (your phone as `+1…`)  
4. In Twilio, set the number’s Messaging webhook to `https://YOUR-APP.onrender.com/webhooks/twilio` (HTTP POST)  
5. Text a photo (green bubble on iPhone)

### Note on free hosting
Render’s free web service sleeps after idle time and uses ephemeral disk, so trip photos can reset when the instance recycles. Fine for trying it out; upgrade later if you want it always-on with durable storage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fe2a1-75a9-78ed-8741-1580a235c2cc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fe2a1-75a9-78ed-8741-1580a235c2cc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

